### PR TITLE
feat: back python compatibility, mac os compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ pip install -r requirements_dev.txt
 Se esegui il programma da **Linux**, sarà necessario aggiungere le seguenti dipendenze da terminale:
 
 ```shell
-sudo apt install portaudio19-dev
-sudo apt install pulseaudio
-sudo apt install espeak
+sudo apt install portaudio19-dev pulseaudio espeak
 ```
+
+Se esegui il programma da **MacOS**, sarà necessario aggiungere le seguenti dipendenze da terminale:
+```shell
+brew install pulseaudio espeak
+```
+Note: con Mac OS 
 
 Esegui poi il programma utilizzando il seguente comando (all'interno della cartella src):
 ```shell

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Se esegui il programma da **MacOS**, sarà necessario aggiungere le seguenti dip
 ```shell
 brew install pulseaudio espeak
 ```
-Note: con Mac OS 
+Note: con Mac OS è possibile dover utilizzare una versione di python 3.7.x per la compatibilità con la libreria pyttsx3.
 
 Esegui poi il programma utilizzando il seguente comando (all'interno della cartella src):
 ```shell

--- a/src/mod_benchmark.py
+++ b/src/mod_benchmark.py
@@ -23,9 +23,10 @@ class ModuleBenchmark(master_module.MasterModule):
     def check_command(self, command: str) -> bool:
         benchmark_regex = r"\b(benchmark|prestazioni)\b.*(?P<selector>\bsistema\b|\bprocessore\b|\bram|memoria\b|\bbatteria\b)"
 
-        if (match := re.search(benchmark_regex, command)) is not None:
+        _match = re.search(benchmark_regex, command)
+        if _match is not None:
             # Se il selector restituisce la parola "sistema", allora inseriamo tutte le info nella risposta
-            if match.group("selector") == "sistema":
+            if _match.group("selector") == "sistema":
                 self.benchmark_cpu = True
                 self.benchmark_ram = True
                 self.benchmark_battery = True

--- a/src/mod_jokes.py
+++ b/src/mod_jokes.py
@@ -12,13 +12,14 @@ class ModuleJokes(master_module.MasterModule):
     def check_command(self, command: str) -> bool:
         regex = r"\b(raccontami|fammi|dimmi)\b.*?\b(barzelletta|battuta)\b.*?(\b(?P<lingua>inglese|tedesco|spagnolo)\b)*$"
         print("check")
-        if (match := re.search(regex, command)) is not None:
-            print(match.group("lingua"))
-            if match.group("lingua") == "inglese":
+        _match = re.search(regex, command)
+        if _match is not None:
+            print(_match.group("lingua"))
+            if _match.group("lingua") == "inglese":
                 self.lang = "en"
-            elif match.group("lingua") == "tedesco":
+            elif _match.group("lingua") == "tedesco":
                 self.lang = "de"
-            elif match.group("lingua") == "spagnolo":
+            elif _match.group("lingua") == "spagnolo":
                 self.lang = "es"
             return True
 

--- a/src/mod_testa_croce.py
+++ b/src/mod_testa_croce.py
@@ -19,5 +19,5 @@ class ModuleTestaCroce(master_module.MasterModule):
         print("Eseguo comando: "+command)
         moneta = random.randint(0, 1) # 0 = Testa, 1 = Croce
         if moneta==0:
-            return "E' uscito testa"
-        return "E' uscito croce"
+            return "È uscito testa"
+        return "È uscito croce"

--- a/src/mod_volume.py
+++ b/src/mod_volume.py
@@ -27,8 +27,9 @@ class ModuleVolume(master_module.MasterModule):
     def check_command(self, command: str) -> bool:
         set_regex = r"\b(?P<command>metti|imposta|setta)\b.*?\bvolume\b.+?\ba\b.+?\b(?P<value>\d+)\b"
 
-        if (match := re.search(set_regex, command)) is not None:
-            value = int(match.group("value"))
+        _match = re.search(set_regex, command)
+        if _match is not None:
+            value = int(_match.group("value"))
             self.value = clamp_val(value)
             self.action_set = True
             self.is_to = True
@@ -36,10 +37,11 @@ class ModuleVolume(master_module.MasterModule):
 
         update_regex = r"\b(?P<command>alza|abbassa)\b.*?\bvolume\b.+?\b(?P<selector>a|di)\b.+?\b(?P<value>\d+)\b"
 
-        if (match := re.search(update_regex, command)) is not None:
-            value = int(match.group("value"))
+        _match = re.search(update_regex, command)
+        if _match is not None:
+            value = int(_match.group("value"))
             self.value = clamp_val(value)
-            self.is_to = match.group("selector") == "a"
+            self.is_to = _match.group("selector") == "a"
             self.is_by = not self.is_to
             self.action_update = True
             return True

--- a/src/my_assistant.py
+++ b/src/my_assistant.py
@@ -41,7 +41,7 @@ except OSError:
 
 # Presa in input una stringa, questa verrà esposta a voce
 def speak(response: str) -> None:
-    if sys.platform == 'Linux':
+    if sys.platform == 'Linux' or sys.platform == 'win32':
         engine.say(response)
         engine.runAndWait()
     elif sys.platform == 'darwin':

--- a/src/my_assistant.py
+++ b/src/my_assistant.py
@@ -1,7 +1,9 @@
 from pyttsx3 import init
 import speech_recognition as sr
-
+import sys
+import os
 import importlib
+
 mod_volume = importlib.import_module('mod_volume')
 mod_jokes = importlib.import_module('mod_jokes')
 mod_time=importlib.import_module('mod_time')
@@ -14,7 +16,13 @@ try:
     reco = sr.Recognizer()
     micro = sr.Microphone()
 
-    engine = init()
+    if sys.platform == 'Linux':
+        engine = init()  # espeak
+    elif sys.platform == 'darwin':
+        engine = init(driverName='dummy')
+    else: # sys.platform == 'win32':
+        engine = init(driverName='sapi5')
+
     voices = engine.getProperty("voices")
 
     # Ricerca indice della lingua italiana nella lista "voices"
@@ -33,8 +41,11 @@ except OSError:
 
 # Presa in input una stringa, questa verrà esposta a voce
 def speak(response: str) -> None:
-    engine.say(response)
-    engine.runAndWait()
+    if sys.platform == 'Linux':
+        engine.say(response)
+        engine.runAndWait()
+    elif sys.platform == 'darwin':
+        os.system(f"echo '{response}' | espeak -v it")
 
 # Inseriamo il nostro comando (vocalmente), quindi questo verrà processato e convertito in una stringa
 def input_command() -> str:

--- a/src/my_assistant.py
+++ b/src/my_assistant.py
@@ -41,7 +41,7 @@ except OSError:
 
 # Presa in input una stringa, questa verrà esposta a voce
 def speak(response: str) -> None:
-    if sys.platform == 'Linux' or sys.platform == 'win32':
+    if sys.platform in ('Linux' , 'win32'):
         engine.say(response)
         engine.runAndWait()
     elif sys.platform == 'darwin':

--- a/tests/test_module_testa_croce.py
+++ b/tests/test_module_testa_croce.py
@@ -29,8 +29,8 @@ functionalities_tests: List[dict] = [
 ]
 
 money_value: List[dict] = [
-    {"value": 0, "response": "E' uscito testa"},
-    {"value": 1, "response": "E' uscito croce"}
+    {"value": 0, "response": "È uscito testa"},
+    {"value": 1, "response": "È uscito croce"}
 ]
 
 @pytest.mark.parametrize("test", functionalities_tests)


### PR DESCRIPTION
Il progetto è veramente figo, purtroppo ero con un mac ed ho provato al volo a rendere il vostro progetto compatibile con il mac.

Per far partire il progetto ho dovuto installare una versione vecchia di python3 per la libreria `pyttsx3`, allo stesso tempo non sono riuscito a far funzionare il driver audio di Mac (dovrebbe essere `nss`, con espeak evidentemente non va), quindi ho bypassato il problema usando `import os` e lanciando il comando espeak da terminale usando `os.system()`, il che è parecchio brutto però meglio di non farlo partire 😁 .

Inoltre, ho rinominato la variabile `match` in `_match` perchè da python3.10 in poi `match` è una [keyword di python](https://learnpython.com/blog/python-match-case-statement/) analoga al classico switch-case. Inoltre, anche se preferisco anch'io usare ` if (match := ...)` per mantenere la variabile `match` sotto lo scope dell'if e risparmiare memoria sempre per motivi di retrocompatibilità l'ho inizializzata fuori dall'if.

sources:
https://github.com/nateshmbhat/pyttsx3/issues/29#issuecomment-682468936
https://stackoverflow.com/questions/74268825/pyttsx3-stopped-working-after-updating-to-macos-ventura
https://learnpython.com/blog/python-match-case-statement/
